### PR TITLE
Point 2023 session links to the tutorial repo's 2023 branch

### DIFF
--- a/2023/sessions/session_1/practical.html
+++ b/2023/sessions/session_1/practical.html
@@ -264,10 +264,10 @@
 <p>The data that we used in this workshop is from the <a href="https://onlinelibrary.wiley.com/doi/10.1002/sim.6605">PennCATH study</a> of coronary artery disease. It includes 1,401 individuals with 861,473 markers and has been made available publicly.</p>
 
 <h3 id="run-standard-qc-steps-using-colab">Run standard QC steps using Colab</h3>
-<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/main/src/01_qc.ipynb">QC Notebook</a> in Google Colab</p>
+<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/2023/src/01_qc.ipynb">QC Notebook</a> in Google Colab</p>
 
 <h3 id="get-access-to-the-data-in-shared-google-drive">Get access to the data in Shared Google Drive</h3>
-<p>For this workshop, we’ll be storing the data on Google Drive. Please consult the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/main/src/01_qc.ipynb">notebook</a> for guidance on accessing the data. Alternatively, you can also execute this notebook in a Jupyter environment, remember to download the data to a location accessible by the Jupyter server and modify the data path variables accordingly. We also included a short video demo on how to mount Google Drive from Google Colab here:</p>
+<p>For this workshop, we’ll be storing the data on Google Drive. Please consult the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/2023/src/01_qc.ipynb">notebook</a> for guidance on accessing the data. Alternatively, you can also execute this notebook in a Jupyter environment, remember to download the data to a location accessible by the Jupyter server and modify the data path variables accordingly. We also included a short video demo on how to mount Google Drive from Google Colab here:</p>
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/v7KiKmEaqnE?si=r11bZduSbdhHmwNf" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen=""></iframe>
 
@@ -282,7 +282,7 @@
 </ul>
 
 <h3 id="assign-ancestry-to-samples-using-grafpop">Assign ancestry to samples using GrafPop</h3>
-<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/main/src/01_1_ancestry.ipynb">Ancestry Notebook</a> in Google Colab</p>
+<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/2023/src/01_1_ancestry.ipynb">Ancestry Notebook</a> in Google Colab</p>
 
 <h2 id="references">References</h2>
 

--- a/2023/sessions/session_2/practical.html
+++ b/2023/sessions/session_2/practical.html
@@ -257,7 +257,7 @@ Familiarity with command-line tools and basic R programming, as we will use the 
 2) Meta-Analysis: Breast Cancer Association Consortium (BCAC) data from 3 different GWAS arrays that has summary statistics and meta-analysis results available publicly.</p>
 
 <h3 id="lets-get-started">Let’s Get Started</h3>
-<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/main/src/02_GWAS%26MetaAnalysis.ipynb">GWAS&amp;MetaAnalysis.ipynb</a> Notebook in Google Colab</p>
+<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/2023/src/02_GWAS%26MetaAnalysis.ipynb">GWAS&amp;MetaAnalysis.ipynb</a> Notebook in Google Colab</p>
 
 </div>
 

--- a/2023/sessions/session_3/practical.html
+++ b/2023/sessions/session_3/practical.html
@@ -252,7 +252,7 @@
 </ul>
 
 <h3 id="lets-start">Let’s start</h3>
-<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/main/src/03_FineMapping%26Colocalization.ipynb">FineMapping&amp;Colocalization.ipynb</a> Notebook in Google Colab</p>
+<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/2023/src/03_FineMapping%26Colocalization.ipynb">FineMapping&amp;Colocalization.ipynb</a> Notebook in Google Colab</p>
 
 </div>
 

--- a/2023/sessions/session_4/practical.html
+++ b/2023/sessions/session_4/practical.html
@@ -216,7 +216,7 @@
 <p>This workshop deploys a precoded Jupyter notebook through Google Colaboratory to perform Heritability and PRS analysis.</p>
 
 <h2 id="lets-get-started">Let’s get started</h2>
-<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/main/src/04_Heritability_PRS.ipynb">04_Heritability_PRS.ipynb</a> Notebook in Google Colab</p>
+<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/2023/src/04_Heritability_PRS.ipynb">04_Heritability_PRS.ipynb</a> Notebook in Google Colab</p>
 
 </div>
 

--- a/2023/sessions/session_5/practical.html
+++ b/2023/sessions/session_5/practical.html
@@ -272,12 +272,12 @@
 </ul>
 
 <h3 id="workshop-material">Workshop Material</h3>
-<p>Due to the time and resource limit of the workshop, we are not going to do a live demo of the preprocessing steps. Please refer to the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/main/src/05_RareVariants/README.md">README.md file</a> for the precoessing steps and the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/tree/main/src/05_RareVariants/1000G/1000G_scripts_part1">1000G_scripts_part1 folder</a> for the preprocessing steps.</p>
+<p>Due to the time and resource limit of the workshop, we are not going to do a live demo of the preprocessing steps. Please refer to the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/2023/src/05_RareVariants/README.md">README.md file</a> for the precoessing steps and the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/tree/2023/src/05_RareVariants/1000G/1000G_scripts_part1">1000G_scripts_part1 folder</a> for the preprocessing steps.</p>
 
-<p>In this workshop, we will be focusing on the R scripts in <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/tree/main/src/05_RareVariants/1000G/1000G_scripts_part2">1000G_scripts_part2</a></p>
+<p>In this workshop, we will be focusing on the R scripts in <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/tree/2023/src/05_RareVariants/1000G/1000G_scripts_part2">1000G_scripts_part2</a></p>
 
 <h3 id="lets-get-started">Let’s get started</h3>
-<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/main/src/05_RareVariants.ipynb">05_RareVariants.ipynb</a> Google colab notebook.</p>
+<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/2023/src/05_RareVariants.ipynb">05_RareVariants.ipynb</a> Google colab notebook.</p>
 
 </div>
 

--- a/2023/sessions/session_6/practical.html
+++ b/2023/sessions/session_6/practical.html
@@ -231,7 +231,7 @@
 <p>This workshop will explore Mendelian randomization analysis using the <a href="https://mrcieu.github.io/TwoSampleMR/">TwoSampleMR</a> R package.</p>
 
 <h3 id="lets-get-started">Let’s get started</h3>
-<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/main/src/06_MR_tutorial.ipynb">06_MR_tutorial.ipynb</a> Google colab notebook.</p>
+<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/2023/src/06_MR_tutorial.ipynb">06_MR_tutorial.ipynb</a> Google colab notebook.</p>
 
 </div>
 

--- a/2023/sessions/session_7/practical.html
+++ b/2023/sessions/session_7/practical.html
@@ -395,7 +395,7 @@ In order to interpret the PRSs as an association “per standard deviation” in
 <p>In our results, we see some variation but a lot of agreement between models, which is great.</p>
 
 <h3 id="lets-get-started">Let’s get started</h3>
-<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/main/src/07_multi_ancestry_analysis.ipynb">07_multi_ancestry_analysis.ipynb</a> Google colab notebook.</p>
+<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/2023/src/07_multi_ancestry_analysis.ipynb">07_multi_ancestry_analysis.ipynb</a> Google colab notebook.</p>
 
 
 </div>

--- a/2023/sessions/session_8/practical.html
+++ b/2023/sessions/session_8/practical.html
@@ -241,7 +241,7 @@
 </ul>
 
 <h3 id="lets-get-started">Let’s get started</h3>
-<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/main/src/08_mCA_colab.ipynb">08_mCA_colab.ipynb</a> Google colab notebook.</p>
+<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/2023/src/08_mCA_colab.ipynb">08_mCA_colab.ipynb</a> Google colab notebook.</p>
 
 </div>
 

--- a/2023/sessions/session_9/practical.html
+++ b/2023/sessions/session_9/practical.html
@@ -236,7 +236,7 @@
 </ol>
 
 <h3 id="lets-get-started">Let’s get started</h3>
-<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/main/src/09_functionalGenomics.ipynb">09_functionalGenomics.ipynb</a> Google colab notebook.</p>
+<p>Please go ahead and open the <a href="https://github.com/DCEG-workshops/statgen_workshop_tutorial/blob/2023/src/09_functionalGenomics.ipynb">09_functionalGenomics.ipynb</a> Google colab notebook.</p>
 
 
 </div>


### PR DESCRIPTION
## What

Repoint the archived **2023** workshop pages' links to the `statgen_workshop_tutorial` repo from its `main` branch to its new frozen **`2023`** branch.

13 links across 9 files (`2023/sessions/session_1…9/practical.html`):
- `…/statgen_workshop_tutorial/blob/main/src/…` → `…/blob/2023/src/…`
- `…/statgen_workshop_tutorial/tree/main/src/…` → `…/tree/2023/src/…`

The GitHub **discussions** links are branch-agnostic and were intentionally left untouched.

## Why

The tutorial repo's `main` branch is being advanced to the 2026 workshop. The 2023 site links directly to `blob/main`, so once `main` changes, those links would resolve to 2026 content (or 404 on renamed files). The tutorial repo now has a permanent `2023` branch (with its in-notebook "Open in Colab" badges also pinned to `blob/2023`), so these archived pages should point there.

## Ordering note

This is safe to merge any time and **should** be merged before the tutorial repo's `main` is replaced with 2026 content. Until then nothing is broken, because `blob/main` currently still serves the 2023 materials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmKELZFNTSzok4oHsN3FBR)_